### PR TITLE
Поддержка шестнадцатеричных цветов

### DIFF
--- a/src/main/java/ru/rey/rrpchat/Utils.java
+++ b/src/main/java/ru/rey/rrpchat/Utils.java
@@ -1,17 +1,21 @@
 package ru.rey.rrpchat;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.List;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
  * Created by Rey on 24.03.2021
  */
 public final class Utils {
-
+    private static final boolean hexSupport = checkHexSupport();
+    private static final Pattern hexPattern = Pattern.compile("\\{#([A-Fa-f0-9]){6}}");
     private static final Random RANDOM = new Random();
 
     public static String extractMessage(String... message) {
@@ -26,6 +30,28 @@ public final class Utils {
 
     public static int getRandom(int max) {
         return RANDOM.nextInt(max);
+    }
+
+    private static boolean checkHexSupport(){
+        String version = Bukkit.getVersion();
+        int start = version.indexOf("MC: ") + 4;
+        int end = version.length() - 1;
+        return Integer.parseInt(version.substring(start, end).split("\\.")[1]) >= 16;
+    }
+
+    public static String parseColors(String message) {
+        String parsed = message;
+
+        if (hexSupport){
+            Matcher matcher = hexPattern.matcher(parsed);
+            while (matcher.find()) {
+                ChatColor hexColor = ChatColor.of(matcher.group().replaceAll("[{}]", ""));
+                String before = parsed.substring(0, matcher.start());
+                String after = parsed.substring(matcher.end());
+                parsed = before + hexColor + after;
+            }
+        }
+        return ChatColor.translateAlternateColorCodes('&', parsed);
     }
 
 }

--- a/src/main/java/ru/rey/rrpchat/commands/CoinCommand.java
+++ b/src/main/java/ru/rey/rrpchat/commands/CoinCommand.java
@@ -31,7 +31,7 @@ public class CoinCommand extends Command {
                 .replace("%result%", result);
 
         Utils.getNearbyPlayers((Player) sender, config.getInt("radius"))
-                .forEach(p -> p.sendMessage(message));
+                .forEach(p -> p.sendMessage(Utils.parseColors(message)));
         return false;
     }
 

--- a/src/main/java/ru/rey/rrpchat/commands/DoCommand.java
+++ b/src/main/java/ru/rey/rrpchat/commands/DoCommand.java
@@ -23,7 +23,7 @@ public class DoCommand extends Command {
         if (!(sender instanceof Player)) return true;
 
         if (args.length < 1) {
-            sender.sendMessage(config.getString("usage"));
+            sender.sendMessage(Utils.parseColors(config.getString("usage")));
             return true;
         }
 
@@ -32,7 +32,7 @@ public class DoCommand extends Command {
                 .replace("%action%", Utils.extractMessage(args));
 
         Utils.getNearbyPlayers((Player) sender, config.getInt("radius"))
-                .forEach(p -> p.sendMessage(message));
+                .forEach(p -> p.sendMessage(Utils.parseColors(message)));
         return false;
     }
 

--- a/src/main/java/ru/rey/rrpchat/commands/GlobalMeCommand.java
+++ b/src/main/java/ru/rey/rrpchat/commands/GlobalMeCommand.java
@@ -24,7 +24,7 @@ public class GlobalMeCommand extends Command {
         if (!(sender instanceof Player)) return true;
 
         if (args.length < 1) {
-            sender.sendMessage(config.getString("usage"));
+            sender.sendMessage(Utils.parseColors(config.getString("usage")));
             return true;
         }
 
@@ -32,7 +32,7 @@ public class GlobalMeCommand extends Command {
                 .replace("%sender%", sender.getName())
                 .replace("%message%", Utils.extractMessage(args));
 
-        Bukkit.getOnlinePlayers().forEach(p -> p.sendMessage(message));
+        Bukkit.getOnlinePlayers().forEach(p -> p.sendMessage(Utils.parseColors(message)));
         return false;
     }
 

--- a/src/main/java/ru/rey/rrpchat/commands/MeCommand.java
+++ b/src/main/java/ru/rey/rrpchat/commands/MeCommand.java
@@ -23,7 +23,7 @@ public class MeCommand extends Command {
         if (!(sender instanceof Player)) return true;
 
         if (args.length < 1) {
-            sender.sendMessage(config.getString("usage"));
+            sender.sendMessage(Utils.parseColors(config.getString("usage")));
             return true;
         }
 
@@ -32,7 +32,7 @@ public class MeCommand extends Command {
                 .replace("%message%", Utils.extractMessage(args));
 
         Utils.getNearbyPlayers((Player) sender, config.getInt("radius"))
-                .forEach(p -> p.sendMessage(message));
+                .forEach(p -> p.sendMessage(Utils.parseColors(message)));
         return false;
     }
 

--- a/src/main/java/ru/rey/rrpchat/commands/TryCommand.java
+++ b/src/main/java/ru/rey/rrpchat/commands/TryCommand.java
@@ -28,7 +28,7 @@ public class TryCommand extends Command {
         if (!(sender instanceof Player)) return true;
 
         if (args.length < 1) {
-            sender.sendMessage(config.getString("usage"));
+            sender.sendMessage(Utils.parseColors(config.getString("usage")));
             return true;
         }
 
@@ -40,7 +40,7 @@ public class TryCommand extends Command {
                 .replace("%result%", result);
 
         Utils.getNearbyPlayers((Player) sender, config.getInt("radius"))
-                .forEach(p -> p.sendMessage(message));
+                .forEach(p -> p.sendMessage(Utils.parseColors(message)));
         return false;
     }
 

--- a/src/main/java/ru/rey/rrpchat/commands/WhisperCommand.java
+++ b/src/main/java/ru/rey/rrpchat/commands/WhisperCommand.java
@@ -23,7 +23,7 @@ public class WhisperCommand extends Command {
         if (!(sender instanceof Player)) return true;
 
         if (args.length < 1) {
-            sender.sendMessage(config.getString("usage"));
+            sender.sendMessage(Utils.parseColors(config.getString("usage")));
             return true;
         }
 
@@ -32,7 +32,7 @@ public class WhisperCommand extends Command {
                 .replace("%message%", Utils.extractMessage(args));
 
         Utils.getNearbyPlayers((Player) sender, config.getInt("radius"))
-                .forEach(p -> p.sendMessage(message));
+                .forEach(p -> p.sendMessage(Utils.parseColors(message)));
         return false;
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: rRPChat
 version: ${project.version}
 main: ru.rey.rrpchat.Core
-api-version: 1.16
+api-version: 1.13
 authors: [ omashune ]
 description: Plugin that adds RP commands
 website: https://github.com/omashune


### PR DESCRIPTION
Привет, добавил в плагин поддержку шестнадцатеричных цветов. 

Чтобы использовать цвет нужно указать его в формате {#??????}
Присутствует проверка на поддержку шестнадцатеричных цветов (версии 1.16 и выше)

Также изменил версию API, используемую для плагина, на 1.13 для возможности запуска на старых версиях.
Протестировано на Paper 1.15.2/1.16.5/1.17.1